### PR TITLE
Adjusting que hyperlink of repo DevSecOpsGuideline on main page of www-project

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ At first, we consider to implement the following steps in a basic pipeline:
 * Compliance check
 
 ## Latest
-You can [read the latest development documents in our official GitHub repository](https://github.com/OWASP/DevSecOpsGuideline/tree/master/documents) or view the latest content at [latest](latest/).
+You can [read the latest development documents in our official GitHub repository](https://github.com/OWASP/DevSecOpsGuideline) or view the latest content at [latest](latest/).
 
 ### Contributions
 Feel free to contribute to this project; any contributors are welcome to make a pull request on [the project repo](https://github.com/OWASP/DevSecOpsGuideline). 


### PR DESCRIPTION
Adjusting the hyperlink of repo DevSecOpsGuideline on main page of www-project-devsecops-guideline, because the hyperlink current is point to "https://github.com/OWASP/DevSecOpsGuideline/tree/master/documents" and this don't exists.